### PR TITLE
[김예지] 4주차 과제 제출

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 
 ## 🍀 Community ERD
 
-[사진]
+![efub_communityERD](https://user-images.githubusercontent.com/121334671/228851047-b347cf3c-e9ed-40e1-a2c5-58a4f09ff380.png)
 
-## 🍀 Community query
 
-[사진]
 
 ## 🍀 Community API 문서 
 
-[노션 링크 첨부]
+[[Notion]](https://artistic-hardboard-4f1.notion.site/3-8f46da0a8bf44b5faadd157e2c101bbb)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 
 ## 🍀 Community ERD
 
-![efub_communityERD](https://user-images.githubusercontent.com/121334671/228851047-b347cf3c-e9ed-40e1-a2c5-58a4f09ff380.png)
-
+![efub_communityERD](https://user-images.githubusercontent.com/121334671/229128343-ec8115c5-9d44-45fe-8d10-059414eff81a.png)
 
 
 ## 🍀 Community API 문서 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 
 ## 🍀 Community ERD
-
-![efub_communityERD](https://user-images.githubusercontent.com/121334671/229128343-ec8115c5-9d44-45fe-8d10-059414eff81a.png)
+![efub_communityERD](https://user-images.githubusercontent.com/121334671/229131641-24a99947-1898-4113-bd13-196f29650101.png)
 
 
 ## 🍀 Community API 문서 

--- a/community/src/main/java/efub/assignment/community/CommunityApplication.java
+++ b/community/src/main/java/efub/assignment/community/CommunityApplication.java
@@ -1,0 +1,11 @@
+package efub.assignment.community;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CommunityApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(CommunityApplication.class, args);
+    }
+}

--- a/community/src/main/java/efub/assignment/community/member/controller/MemberController.java
+++ b/community/src/main/java/efub/assignment/community/member/controller/MemberController.java
@@ -1,0 +1,49 @@
+package efub.assignment.community.member.controller;
+
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.dto.MemberResponseDto;
+import efub.assignment.community.member.dto.MemberUpdateRequestDto;
+import efub.assignment.community.member.dto.SignUpRequestDto;
+import efub.assignment.community.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping
+    @ResponseStatus(value = HttpStatus.CREATED)
+    public MemberResponseDto signUp(@RequestBody @Valid SignUpRequestDto requestDto){
+        Long id = memberService.signUp(requestDto);
+        Member findMember = memberService.findMemberById(id);
+        return MemberResponseDto.from(findMember);
+    }
+
+    @GetMapping("/{memberId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public MemberResponseDto getMember(@PathVariable Long memberId){
+        Member findMember = memberService.findMemberById(memberId);
+        return MemberResponseDto.from(findMember);
+    }
+
+    @PatchMapping("/profile/{memberId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public MemberResponseDto update(@PathVariable final Long memberId, @RequestBody @Valid final MemberUpdateRequestDto responseDto){
+        Long id = memberService.update(memberId, responseDto);
+        Member findMember = memberService.findMemberById(id);
+        return MemberResponseDto.from(findMember);
+    }
+
+    @PatchMapping("/{memberId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public String withdraw(@PathVariable Long memberId){
+        memberService.withdraw(memberId);
+        return "성공적으로 탈퇴가 완료되었습니다.";
+    }
+}

--- a/community/src/main/java/efub/assignment/community/member/domain/Member.java
+++ b/community/src/main/java/efub/assignment/community/member/domain/Member.java
@@ -1,0 +1,56 @@
+package efub.assignment.community.member.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", updatable = false)
+    private Long memberId;
+
+
+    @Column(nullable = false, length = 60)
+    private String email;
+
+    @Column(nullable = false)
+    private String encodedPassword;
+
+    @Column(nullable = false, updatable = false, length = 16)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String university;
+
+    @Column(nullable = false)
+    private String studentId;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    @Builder
+    public Member(String email, String password, String nickname, String university, String studentId){
+        this.email = email;
+        this.encodedPassword = password;
+        this.nickname = nickname;
+        this.university = university;
+        this.studentId = studentId;
+        this.status = MemberStatus.REGISTERED;
+    }
+
+    public void updateMember(String nickname){
+        this.nickname = nickname;
+    }
+
+    public void withdrawMember(){
+        this.status = MemberStatus.UNREGISTERED;
+    }
+}

--- a/community/src/main/java/efub/assignment/community/member/domain/MemberStatus.java
+++ b/community/src/main/java/efub/assignment/community/member/domain/MemberStatus.java
@@ -1,0 +1,15 @@
+package efub.assignment.community.member.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberStatus {
+    REGISTERED(0, "등록상태", "사용자 등록상태"),
+    UNREGISTERED(1, "해지", "사용자 해지상태");
+
+    private final Integer Id;
+    private final String title;
+    private final String description;
+}

--- a/community/src/main/java/efub/assignment/community/member/dto/MemberResponseDto.java
+++ b/community/src/main/java/efub/assignment/community/member/dto/MemberResponseDto.java
@@ -1,0 +1,32 @@
+package efub.assignment.community.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import efub.assignment.community.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MemberResponseDto {
+    private String email;
+    private String nickname;
+    private String university;
+    private String studentId;
+
+    public MemberResponseDto(String email, String nickname, String university, String studentId){
+        this.email = email;
+        this.nickname = nickname;
+        this.university = university;
+        this.studentId = studentId;
+    }
+
+    public static MemberResponseDto from(Member member){
+        return new MemberResponseDto(
+                member.getEmail(),
+                member.getNickname(),
+                member.getUniversity(),
+                member.getStudentId());
+    }
+}

--- a/community/src/main/java/efub/assignment/community/member/dto/MemberUpdateRequestDto.java
+++ b/community/src/main/java/efub/assignment/community/member/dto/MemberUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package efub.assignment.community.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberUpdateRequestDto {
+    @NotBlank(message = "닉네임은 필수값입니다.")
+    private String nickname;
+
+    @Builder
+    public MemberUpdateRequestDto(String nickname){
+        this.nickname = nickname;
+    }
+
+}

--- a/community/src/main/java/efub/assignment/community/member/dto/SignUpRequestDto.java
+++ b/community/src/main/java/efub/assignment/community/member/dto/SignUpRequestDto.java
@@ -1,0 +1,53 @@
+package efub.assignment.community.member.dto;
+
+import efub.assignment.community.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignUpRequestDto {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효하지 않은 이메일 형식입니다.", regexp = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!.?,])[A-Za-z\\d!.?,]{2,16}$",
+            message = "16자 이내의 영문자 및 숫자와 ?,!,., , 특수문자로 입력해주세요.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    private String nickname;
+
+    @NotBlank(message = "학교는 필수입니다.")
+    private String university;
+
+    @NotBlank(message = "학번은 필수입니다.")
+    private String studentId;
+
+    @Builder
+    public SignUpRequestDto(String email, String password, String nickname, String university, String studentId){
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.university = university;
+        this.studentId = studentId;
+    }
+
+    public Member toEntity(){
+        return Member.builder()
+                .email(this.email)
+                .password(this.password)
+                .nickname(this.nickname)
+                .university(this.university)
+                .studentId(this.studentId)
+                .build();
+    }
+
+}

--- a/community/src/main/java/efub/assignment/community/member/global/entity/BaseTimeEntity.java
+++ b/community/src/main/java/efub/assignment/community/member/global/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package efub.assignment.community.member.global.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(updatable = false)
+    private LocalDateTime modifiedDate;
+}

--- a/community/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
+++ b/community/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package efub.assignment.community.member.repository;
+
+import efub.assignment.community.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Boolean existsByEmail(String email);
+}

--- a/community/src/main/java/efub/assignment/community/member/service/MemberService.java
+++ b/community/src/main/java/efub/assignment/community/member/service/MemberService.java
@@ -1,0 +1,48 @@
+package efub.assignment.community.member.service;
+
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.dto.MemberUpdateRequestDto;
+import efub.assignment.community.member.dto.SignUpRequestDto;
+import efub.assignment.community.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Long signUp(SignUpRequestDto requestDto){
+        if(existsByEmail(requestDto.getEmail())){
+            throw new IllegalArgumentException("이미 존재하는 email입니다. email="+requestDto.getEmail());
+        }
+        Member member = memberRepository.save(requestDto.toEntity());
+        return member.getMemberId();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByEmail(String email){
+        return memberRepository.existsByEmail(email);
+    }
+
+    @Transactional(readOnly = true)
+    public Member findMemberById(Long id){
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("해당 id를 가진 Member를 찾을 수 없습니다. id="+id));
+    }
+
+    public Long update(Long memberId, MemberUpdateRequestDto requestDto){
+        Member member = findMemberById(memberId);
+        member.updateMember(requestDto.getNickname());
+        return member.getMemberId();
+    }
+
+    public void withdraw(Long memberId){
+        Member member = findMemberById(memberId);
+        member.withdrawMember();
+    }
+}

--- a/community/src/test/java/efub/assignment/community/member/service/MemberServiceTest.java
+++ b/community/src/test/java/efub/assignment/community/member/service/MemberServiceTest.java
@@ -1,0 +1,106 @@
+package efub.assignment.community.member.service;
+
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.dto.MemberUpdateRequestDto;
+import efub.assignment.community.member.dto.SignUpRequestDto;
+import efub.assignment.community.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @BeforeEach
+    void beforeEach(){ memberRepository.deleteAll(); }
+
+    @Test
+    @DisplayName("create member")
+    public void testSignUp() {
+        //given
+        String email = "email@naver.com";
+        String password = "password";
+        String nickname = "nickname";
+        String university = "이화여자대학교";
+        String studentId = "2176082";
+        SignUpRequestDto requestDto = SignUpRequestDto.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        //when
+        Long memberId = memberService.signUp(requestDto);
+
+        //then
+        Member member = memberRepository.findById(memberId).orElse(null);
+        assertNotNull(member);
+        assertEquals(requestDto.getEmail(), member.getEmail());
+        assertEquals(requestDto.getNickname(), member.getNickname());
+        assertEquals(requestDto.getUniversity(), member.getUniversity());
+        assertEquals(requestDto.getStudentId(), member.getStudentId());
+    }
+
+    @Test
+    @DisplayName("update member profile")
+    public void testUpdate() {
+        //given
+        Member member = Member.builder()
+                .email("email@naver.com")
+                .password("Password!")
+                .nickname("nickname")
+                .university("이화여자대학교")
+                .studentId("2176082")
+                .build();
+        memberRepository.save(member);
+        Long memberId = member.getMemberId();
+
+        String nickname = "new_nickname";
+        MemberUpdateRequestDto requestDto = MemberUpdateRequestDto.builder()
+                .nickname(nickname)
+                .build();
+
+        //when
+        Long updatedMemberId = memberService.update(memberId, requestDto);
+
+        //then
+        assertEquals(memberId, updatedMemberId);
+        Member updateMember = memberRepository.findById(memberId).orElse(null);
+        assertNotNull(updateMember);
+        assertEquals(requestDto.getNickname(), updateMember.getNickname());
+    }
+
+    @Test
+    @DisplayName("withdraw member")
+    public void withdraw() {
+        //given
+        Member member = Member.builder()
+                .email("email@naver.com")
+                .password("Password!")
+                .nickname("nickname")
+                .university("이화여자대학교")
+                .studentId("2176082")
+                .build();
+        memberRepository.save(member);
+        Long memberId = member.getMemberId();
+
+        //when
+        memberService.withdraw(memberId);
+
+        //then
+        Member deletedMember = memberRepository.findById(memberId).orElse(null);
+        assertNotNull(deletedMember);
+    }
+}


### PR DESCRIPTION
# 구현 기능(수행 과제 내용)
스프링부트를 활용하여 member의 생성, 조회, 수정, 삭제(CRUD)를 구현하고, 테스트 코드를 작성하였다.
<br>

# 과제 정리
### 프로젝트 구조
- Domain : 소프트웨어로 해결하고자 하는 문제 영역
- DTO (Data Transfer Object) : 계층끼리 데이터를 주고받을 수 있게 하는 객체
- Controller : 사용자의 요청에 대해 Json 형태로 객체 데이터를 반환
- Service : 비즈니스 로직 수행
- Repository : 도메인 객체를 관리하는 저장소

### extra
노션 과제 안내 페이지의 참고 API 문서처럼, JSON 형태로 응답을 받았을 때 `memberId`가 반환되지 않도록 만들고 싶어서 방법을 찾아보고 그것을 적용해보았다. 🔗 [JSON 응답 시 memberId 제외하기](https://velog.io/@xyzw/EFUB-%EC%84%B8%EC%85%98-4%EC%A3%BC%EC%B0%A8-%EA%B3%BC%EC%A0%9C-extra)
<br>

# 어려웠던 점(생략 가능)
### Git
3주차 코드가 base에 머지되기 전에 4주차 코드를 내 브랜치에 푸시했더니, 3주차 머지에 4주차 코드가 포함되어 4주차 제출 PR를 보낼 수가 없었다. 그래서 base repository의 기존 member/YJ-Lee-Kim 브랜치를 삭제하고 다시 생성하여 PR를 보내게 되었다. 앞으로 커밋/푸시하기 전에 이전 주차의 코드가 머지되었는지를 먼저 확인해야겠다.

#### 정리
- 머지를 하기 전 커밋들은 해당 PR에 계속 쌓인다!
- PR를 날린 상황에서 커밋을 했을 때, 머지하지 않고 close하면 다른 PR를 만들 수 있고, 이 PR에는 예전 커밋과 최신 커밋이 쌓여있다!

